### PR TITLE
Lesson 4 - From Ecto to rendering data in LiveView

### DIFF
--- a/lib/slax_web/live/chat_room/helpers/room_helpers.ex
+++ b/lib/slax_web/live/chat_room/helpers/room_helpers.ex
@@ -1,7 +1,9 @@
 defmodule SlaxWeb.Live.ChatRoom.Helpers.Room do
-  alias SlaxWeb.Live.ChatRoom.Entities.Room
+  alias Slax.Repo
+  alias Slax.Chat.Room
 
   @initial_users_in_room 0
+  @max_allowed_rooms 10_000_000
 
   @moduledoc """
   A helper module for managing chat rooms.
@@ -9,71 +11,15 @@ defmodule SlaxWeb.Live.ChatRoom.Helpers.Room do
   This module provides functions for generating and managing a chat room.
   """
 
-  @doc """
-  Builds a new chat room.
-
-  The function generates a random room ID between 0 and the given `max_rooms_supported` value.
-  It then generates a random room name by picking a superhero from a predefined list of names
-  and appending the room ID to it.
-
-  The function returns a `%Room{}` struct containing the `room_id` and `room_name`.
-
-  ## Parameters
-
-    - `max_rooms_supported`: A positive number representing the maximum number of chat rooms
-      supported. It can be an integer or a float. The function will generate a random room ID
-      between 0 and this value.
-
-  ## Returns
-
-    - `{:ok, %Room{}}`: A tuple containing the successfully created chat room struct.
-    - `{:error, reason}`: A tuple with an error message if the `max_rooms_supported` is invalid
-      (not a positive number).
-
-  ## Examples
-
-      iex> SlaxWeb.Live.ChatRoom.Helpers.Room.build_chat_room(1000)
-      {:ok, %Room{room_id: 4523, room_name: "Iron man - 4523"}}
-
-      iex> SlaxWeb.Live.ChatRoom.Helpers.Room.build_chat_room(-1)
-      {:error, "Invalid input: max_rooms_supported must be a positive number"}
-
-  """
-  def build_chat_room(max_rooms_supported) when is_number(max_rooms_supported) and max_rooms_supported > 0 do
-    room_id = Enum.random(0..max_rooms_supported)
-    room_name = generate_room_name_random(room_id)
-
-    {:ok, %Room{room_id: room_id, room_name: room_name, user_connected_count: @initial_users_in_room}}
-  end
-
-  # Error handling for invalid inputs (non-numbers or non-positive numbers)
-  def build_chat_room(_) do
-    {:error, "Invalid input: max_rooms_supported must be a positive number"}
-  end
-
-  @doc """
-  Checks if there are any users connected to the chat room.
-
-  ## Examples
-
-      iex> SlaxWeb.Live.ChatRoom.Helpers.Room.anyone_connected?(%ChatRoom{user_connected_count: 5})
-      true
-
-      iex> SlaxWeb.Live.ChatRoom.Helpers.Room.anyone_connected?(%ChatRoom{user_connected_count: 0})
-      false
-
-  """
-  def anyone_connected?(chat_room), do: chat_room.user_connected_count > 0
-
-  defp generate_room_name_random(room_id) do
+  def generate_room_name_random() do
     marvel_heroes_names = ["Iron man", "Spider-man", "Hawkeye", "Nick Furry", "Nebula", "Ant-man", "Phoenix", "Wanda"]
+    random_id = Enum.random(0..@max_allowed_rooms)
 
-    # Ensure the list is not empty before attempting random selection
     if length(marvel_heroes_names) == 0 do
       {:error, "No names available for chat room generation"}
     else
       hero_picked = Enum.random(marvel_heroes_names)
-      "#{hero_picked} - #{room_id}"
+      "#{hero_picked} - #{random_id}"
     end
   end
 end

--- a/lib/slax_web/live/chat_room/page/room_page.ex
+++ b/lib/slax_web/live/chat_room/page/room_page.ex
@@ -5,35 +5,52 @@ defmodule SlaxWeb.Live.ChatRoom.Page do
 
   @max_number_of_rooms 10_000_000
 
+
   def render(assigns) do
-    case Room.build_chat_room(@max_number_of_rooms) do
-      {:ok, chat_room_entity} ->
-        # Properly assign chat_room_entity to assigns
-        assigns = assign(assigns, :chat_room_entity, chat_room_entity)
-
-        ~H"""
-        <div id={"room-#{@chat_room_entity.room_id}"}>
-          <div>
-            <%= "Welcome to this awesome chat room! This is the room ID: #{@chat_room_entity.room_name}" %>
-          </div>
-
-          <%= if Room.anyone_connected?(@chat_room_entity) do %>
-            <div>
-              <%= "You are among #{@chat_room_entity.user_connected_count - 1} users connected" %>
-            </div>
-          <% else %>
-            <div>No one else is connected here except for you 🥲 </div>
-          <% end %>
-        </div>
-        """
-
-      {:error, message} ->
-        # Assign error message to assigns
-        assigns = assign(assigns, :error_message, message)
-
-        ~H"""
-        <div>Failed to generate chat room: #{@error_message}</div>
-        """
-    end
+    ~H"""
+   <div>Welcome to the chat!</div>
+   <div class="flex flex-col flex-grow shadow-lg">
+     <div class="flex justify-between items-center flex-shrink-0 h-16 bg-white border-b border-slate-300 px-4">
+       <div class="flex flex-col gap-1.5">
+         <h1 class="text-sm font-bold leading-none">
+           #room-name
+         </h1>
+         <div class="text-xs leading-none h-3.5">Placeholder topic</div>
+       </div>
+     </div>
+   </div>
+   """
   end
+
+  # def render(assigns) do
+  #   case Room.build_chat_room(@max_number_of_rooms) do
+  #     {:ok, chat_room_entity} ->
+  #       # Properly assign chat_room_entity to assigns
+  #       assigns = assign(assigns, :chat_room_entity, chat_room_entity)
+
+  #       ~H"""
+  #       <div id={"room-#{@chat_room_entity.room_id}"}>
+  #         <div>
+  #           <%= "Welcome to this awesome chat room! This is the room ID: #{@chat_room_entity.room_name}" %>
+  #         </div>
+
+  #         <%= if Room.anyone_connected?(@chat_room_entity) do %>
+  #           <div>
+  #             <%= "You are among #{@chat_room_entity.user_connected_count - 1} users connected" %>
+  #           </div>
+  #         <% else %>
+  #           <div>No one else is connected here except for you 🥲 </div>
+  #         <% end %>
+  #       </div>
+  #       """
+
+  #     {:error, message} ->
+  #       # Assign error message to assigns
+  #       assigns = assign(assigns, :error_message, message)
+
+  #       ~H"""
+  #       <div>Failed to generate chat room: #{@error_message}</div>
+  #       """
+  #   end
+  # end
 end

--- a/lib/slax_web/live/chat_room/page/room_page.ex
+++ b/lib/slax_web/live/chat_room/page/room_page.ex
@@ -12,55 +12,26 @@ defmodule SlaxWeb.Live.ChatRoom.Page do
   def mount(_params, _session, socket) do
     slax_chat_room = RoomQueries.get_first_room()
 
-    socket = assign(socket, slax_room: slax_chat_room)
+    # Keep the :slax_room key
+    socket = assign(socket, :slax_room, slax_chat_room)
 
     {:ok, socket}
   end
 
   def render(assigns) do
     ~H"""
-   <div class="flex flex-col flex-grow shadow-lg">
-     <div class="flex justify-between items-center flex-shrink-0 h-16 bg-white border-b border-slate-300 px-4">
-       <div class="flex flex-col gap-1.5">
-         <h1 class="text-sm font-bold leading-none">
-           #room-name
-         </h1>
-         <div class="text-xs leading-none h-3.5">Placeholder topic</div>
-       </div>
-     </div>
-   </div>
-   """
+    <div class="flex flex-col flex-grow shadow-lg">
+      <div class="flex justify-between items-center flex-shrink-0 h-16 bg-white border-b border-slate-300 px-4">
+        <div class="flex flex-col gap-1.5">
+          <h1 class="text-sm font-bold leading-none">
+            #room-name
+            <%= @slax_room.name %>
+          </h1>
+          <div class="text-xs leading-none h-3.5">Placeholder topic</div>
+          <div class="text-xs leading-none h-3.5"><%= @slax_room.topic %></div>
+        </div>
+      </div>
+    </div>
+    """
   end
-
-  # def render(assigns) do
-  #   case Room.build_chat_room(@max_number_of_rooms) do
-  #     {:ok, chat_room_entity} ->
-  #       # Properly assign chat_room_entity to assigns
-  #       assigns = assign(assigns, :chat_room_entity, chat_room_entity)
-
-  #       ~H"""
-  #       <div id={"room-#{@chat_room_entity.room_id}"}>
-  #         <div>
-  #           <%= "Welcome to this awesome chat room! This is the room ID: #{@chat_room_entity.room_name}" %>
-  #         </div>
-
-  #         <%= if Room.anyone_connected?(@chat_room_entity) do %>
-  #           <div>
-  #             <%= "You are among #{@chat_room_entity.user_connected_count - 1} users connected" %>
-  #           </div>
-  #         <% else %>
-  #           <div>No one else is connected here except for you 🥲 </div>
-  #         <% end %>
-  #       </div>
-  #       """
-
-  #     {:error, message} ->
-  #       # Assign error message to assigns
-  #       assigns = assign(assigns, :error_message, message)
-
-  #       ~H"""
-  #       <div>Failed to generate chat room: #{@error_message}</div>
-  #       """
-  #   end
-  # end
 end

--- a/lib/slax_web/live/chat_room/page/room_page.ex
+++ b/lib/slax_web/live/chat_room/page/room_page.ex
@@ -1,14 +1,7 @@
 defmodule SlaxWeb.Live.ChatRoom.Page do
   use SlaxWeb, :live_view
 
-  import Ecto.Query
-
-  alias SlaxWeb.Live.ChatRoom.Helpers.Room
-  alias Slax.Repo
-  alias Slax.Chat.Room
-
-  @paginated_results_limit 100
-  @max_number_of_rooms 10_000_000
+  alias SlaxWeb.Live.ChatRoom.{Querying.RoomQueries, Helpers.Room}
 
   # When a LiveView page is opened, the first thing that gets done is mounting the page. It's the LiveView entrypoint.
   # mount/3 is called 2x; once of the page loads and then again to establish the live websocket.
@@ -17,34 +10,11 @@ defmodule SlaxWeb.Live.ChatRoom.Page do
   # Source: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#c:mount/3
 
   def mount(_params, _session, socket) do
-    slax_chat_room =
-      build_room_query()
-      |> fetch_first_room()
+    slax_chat_room = RoomQueries.get_first_room()
 
-    socket =
-      socket
-      |> assign(slax_room: slax_chat_room)
+    socket = assign(socket, slax_room: slax_chat_room)
 
     {:ok, socket}
-  end
-
-  defp build_room_query(opts \\ []) do
-    Room
-    |> select([r], r)
-    |> apply_limit(opts)
-    |> apply_offset(opts)
-  end
-
-  defp fetch_first_room(query), do: Repo.one(query)
-
-  defp apply_limit(query, opts) do
-    limit = Keyword.get(opts, :limit, @paginated_results_limit)
-    from(r in query, limit: ^limit)
-  end
-
-  defp apply_offset(query, opts) do
-    offset = Keyword.get(opts, :offset, 0)
-    from(r in query, offset: ^offset)
   end
 
   def render(assigns) do

--- a/lib/slax_web/live/chat_room/page/room_page.ex
+++ b/lib/slax_web/live/chat_room/page/room_page.ex
@@ -1,14 +1,54 @@
 defmodule SlaxWeb.Live.ChatRoom.Page do
   use SlaxWeb, :live_view
 
-  alias SlaxWeb.Live.ChatRoom.Helpers.Room
+  import Ecto.Query
 
+  alias SlaxWeb.Live.ChatRoom.Helpers.Room
+  alias Slax.Repo
+  alias Slax.Chat.Room
+
+  @paginated_results_limit 100
   @max_number_of_rooms 10_000_000
 
+  # When a LiveView page is opened, the first thing that gets done is mounting the page. It's the LiveView entrypoint.
+  # mount/3 is called 2x; once of the page loads and then again to establish the live websocket.
+  # The live websocket is used to make a point of contact between the browser and the backend server.
+  # If it isn't defined on a page, Phoenix will fall back to a given default behavior.
+  # Source: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#c:mount/3
+
+  def mount(_params, _session, socket) do
+    slax_chat_room =
+      build_room_query()
+      |> fetch_first_room()
+
+    socket =
+      socket
+      |> assign(slax_room: slax_chat_room)
+
+    {:ok, socket}
+  end
+
+  defp build_room_query(opts \\ []) do
+    Room
+    |> select([r], r)
+    |> apply_limit(opts)
+    |> apply_offset(opts)
+  end
+
+  defp fetch_first_room(query), do: Repo.one(query)
+
+  defp apply_limit(query, opts) do
+    limit = Keyword.get(opts, :limit, @paginated_results_limit)
+    from(r in query, limit: ^limit)
+  end
+
+  defp apply_offset(query, opts) do
+    offset = Keyword.get(opts, :offset, 0)
+    from(r in query, offset: ^offset)
+  end
 
   def render(assigns) do
     ~H"""
-   <div>Welcome to the chat!</div>
    <div class="flex flex-col flex-grow shadow-lg">
      <div class="flex justify-between items-center flex-shrink-0 h-16 bg-white border-b border-slate-300 px-4">
        <div class="flex flex-col gap-1.5">

--- a/lib/slax_web/live/chat_room/querying/room_querier.ex
+++ b/lib/slax_web/live/chat_room/querying/room_querier.ex
@@ -1,0 +1,27 @@
+defmodule SlaxWeb.Live.ChatRoom.Querying.RoomQueries do
+  import Ecto.Query
+
+  alias Slax.Repo
+  alias Slax.Chat.Room
+
+  @paginated_results_limit 100
+
+  @paginated_results_limit 100
+
+  def get_first_room(opts \\ []) do
+    Room
+    |> apply_limit(opts)
+    |> apply_offset(opts)
+    |> Repo.one()
+  end
+
+  defp apply_limit(query, opts) do
+    limit = Keyword.get(opts, :limit, @paginated_results_limit)
+    from(r in query, limit: ^limit)
+  end
+
+  defp apply_offset(query, opts) do
+    offset = Keyword.get(opts, :offset, 0)
+    from(r in query, offset: ^offset)
+  end
+end

--- a/lib/slax_web/live/chat_room/querying/room_querier.ex
+++ b/lib/slax_web/live/chat_room/querying/room_querier.ex
@@ -8,6 +8,7 @@ defmodule SlaxWeb.Live.ChatRoom.Querying.RoomQueries do
 
   @paginated_results_limit 100
 
+  @spec get_first_room() :: any()
   def get_first_room(opts \\ []) do
     Room
     |> apply_limit(opts)


### PR DESCRIPTION
In this lesson, we're focused on leveraging Ecto to compose a query and fetch a chat room from Postgres.

I built a module focused on building queries on top of the lesson, which is leveraged by the chat room live page. This allows for a clean separation of concerns, as it doesn't need to know what happens.

We also add the mounting logic for the page. There's a default behavior, but in this instance, we're fetching the chatroom and assigning it to the web socket by the time it's live.

In the page, we're rendering the content from the chat room entity we fetched through the 'querier'.