### PR TITLE
Adding production-like Docker environment for Slax

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Ignore files and directories that aren't needed in the container
+.git
+_build
+deps
+node_modules
+test
+*.md
+docker-compose.*
+.env
+
+# Allow mix.exs and mix.lock explicitly
+!mix.exs
+!mix.lock

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,36 @@
+FROM node:20-slim AS node-build
+
+WORKDIR /app/assets
+
+# 1. Copy package.json and lock file, then install dependencies
+COPY assets/package.json assets/package-lock.json ./
+RUN npm install
+
+# 2. Copy all other assets (including vendor/topbar.js)
+COPY assets/ ./
+
+# 3. Build static assets
+RUN npx esbuild js/app.js --bundle --minify --sourcemap --outdir=../priv/static/assets
+
+# Stage 2: Elixir Build Stage
+FROM elixir:1.18-otp-27-alpine AS build
+
+RUN apk add --no-cache build-base git npm bash curl
+WORKDIR /app
+RUN mix local.hex --force && mix local.rebar --force
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only prod
+COPY . .
+RUN mix deps.compile
+# Copy built assets from Node.js stage
+COPY --from=node-build /app/assets ../priv/static/assets
+RUN mix phx.digest
+
+# Stage 3: Minimal Runtime Container
+FROM gcr.io/distroless/base-debian11:latest
+
+WORKDIR /app
+COPY --from=build /app/_build/prod/rel/slax ./
+USER nobody:nogroup
+EXPOSE 4000
+CMD ["bin/slax", "start"]

--- a/assets/package.json
+++ b/assets/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "tailwind.config.js",
   "scripts": {
-    "deploy": "esbuild app.js --bundle --minify --sourcemap --outdir=../priv/static/assets",
+    "deploy": "esbuild js/app.js --bundle --minify --sourcemap --outdir=../priv/static/assets",
     "watch": "esbuild app.js --bundle --watch --sourcemap --outdir=../priv/static/assets"
   },
   "keywords": [],


### PR DESCRIPTION
## What's being done
We continue the work established earlier for containerizing Slax for development and production

- https://github.com/Elixir-journey/slax/issues/13 

## Containerizing Slax
### Development environment
Prior (yesterday), I added a Docker development environment (https://github.com/Elixir-journey/slax/pull/16). To be able to set the Slax Phoenix/LiveView application onto a Docker environment for development, we needed to:
- Use [a base Elixir+Erlang image](https://github.com/erlef/docker-elixir/blob/62ca4fe3f6106e8a2a325de00b667bef6505475c/1.18/alpine/Dockerfile)
- Include everything needed in development to run the Phoenix app in development mode [(Elixir, Node, Postgres client, etc..)](https://github.com/Elixir-journey/slax/blob/7507a34b90e10ead77deb241f3b89a350b7325ed/Dockerfile.dev#L4-L13)
- Install and compile Elixir/NPM dependencies, and finally run the server on port 4000

### Production environment

Albeit it's a follow-along project, I decided to invest a little bit more energy towards a more quality production environment. In the development container, since we're embedding all the development dependencies within the container, it makes unnecessarily bloated and makes it easier to penetrate the system. I'm not a security specialist, but there are still a few things that can be done in production ensuring that we're providing a safe and enjoyable platform for Slax users (e.g., me)


The docker container for production is being built in 3 stages. The Node build installs the dependencies set in app/assets , copies what's in the assets folder and runs esbuild to bundle + minify static files. The Elixir build stage installs Hex and Rebar, fetches + compiles dependencies for production, copies compiled assets from the Node build stage and runs  The Distroless runtime stage copies the compiled production binaries in the Elixir stage into a minimal Distroless image (very lean Unix runtime to reduce attack opportunities), sets the working directory to /app and starts the Phoenix server.